### PR TITLE
Fix 2 unneccessary empty line bugs

### DIFF
--- a/moderncvbodyiii.sty
+++ b/moderncvbodyiii.sty
@@ -143,13 +143,13 @@
   \renewcommand*{\subsectionrule}{}\fi
 
 \renewcommand*{\cvitem}[3][.25em]{%
-  \ifthenelse{\equal{#2}{}}{}{\hintstyle{#2}: }{#3}%
+  \ifstrempty{#2}{}{\hintstyle{#2}: }{#3}%
   \par\addvspace{#1}}
 
 \renewcommand*{\cvdoubleitem}[5][.25em]{%
   \begin{minipage}[t]{\doubleitemcolumnwidth}\hintstyle{#2}: #3\end{minipage}%
   \hfill% fill of \separatorcolumnwidth
-  \begin{minipage}[t]{\doubleitemcolumnwidth}\ifthenelse{\equal{#4}{}}{}{\hintstyle{#4}: }#5\end{minipage}%
+  \begin{minipage}[t]{\doubleitemcolumnwidth}\ifstrempty{#4}{}{\hintstyle{#4}: }#5\end{minipage}%
   \par\addvspace{#1}}
 
 \renewcommand*{\cvlistitem}[2][.25em]{%
@@ -159,14 +159,20 @@
 \renewcommand*{\cvlistdoubleitem}[3][.25em]{%
   \cvitem[#1]{}{\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#2\end{minipage}%
   \hfill% fill of \separatorcolumnwidth
-  \ifthenelse{\equal{#3}{}}%
+  \ifstrempty{#3}%
     {}%
     {\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#3\end{minipage}}}}
 
 \renewcommand*{\cventry}[7][.25em]{
   \begin{tabular*}{\maincolumnwidth}{l@{\extracolsep{\fill}}r}%
-    {\bfseries #4} & {\bfseries #5}\\%
-    {\itshape #3\ifthenelse{\equal{#6}{}}{}{, #6}} & {\itshape #2}\\%
+    % skip the company name and location line if both are empty, allowing one to show multiple roles within the same company without repeating it
+    \ifboolexpr{%
+      test {\ifstrempty{#4}}
+      and
+      test {\ifstrempty{#5}}}%
+      {}%
+      {{\bfseries #4} & {\bfseries #5}\\}%
+    {\itshape #3\ifstrempty{#6}{}{, #6}} & {\itshape #2}\\%
   \end{tabular*}%
   \ifx&#7&%
   \else{\\%
@@ -179,7 +185,7 @@
 \@initializelength{\cvitemwithcommentmainlength}
 \@initializelength{\cvitemwithcommentcommentlength}
 \renewcommand*{\cvitemwithcomment}[4][.25em]{%
-  \savebox{\cvitemwithcommentmainbox}{\ifthenelse{\equal{#2}{}}{}{\hintstyle{#2}: }#3}%
+  \savebox{\cvitemwithcommentmainbox}{\ifstrempty{#2}{}{\hintstyle{#2}: }#3}%
   \setlength{\cvitemwithcommentmainlength}{\widthof{\usebox{\cvitemwithcommentmainbox}}}%
   \setlength{\cvitemwithcommentcommentlength}{\maincolumnwidth-\separatorcolumnwidth-\cvitemwithcommentmainlength}%
   \begin{minipage}[t]{\cvitemwithcommentmainlength}\usebox{\cvitemwithcommentmainbox}\end{minipage}%

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -70,10 +70,11 @@
     \@firstmakeheaddetailselementfalse\fi}
 %   internal command to flush the makehead
 \@initializecommand{\flushmakeheaddetails}{%
-  \strut\usebox{\makeheaddetailsbox}%
-  \savebox{\makeheaddetailsbox}{}%
-  \savebox{\makeheaddetailstempbox}{}%
-  \setlength{\makeheaddetailsboxwidth}{0pt}}
+  \ifnum\makeheaddetailsboxwidth>0%
+    \strut\usebox{\makeheaddetailsbox}%
+    \savebox{\makeheaddetailsbox}{}%
+    \savebox{\makeheaddetailstempbox}{}%
+    \setlength{\makeheaddetailsboxwidth}{0pt}\fi}
 \@initializecommand{\makehead}{%
   \setlength{\makeheaddetailswidth}{0.8\textwidth}%
   \hfil%
@@ -81,9 +82,10 @@
     \centering%
     % name and title
     \namestyle{\@firstname~\@lastname}%
-    \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}\\% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title) 
+    \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title) 
     % optional detailed information
     \if@details{%
+      \\%
       \addressfont\color{color2}%
       \ifthenelse{\isundefined{\@addressstreet}}{}{\addtomakeheaddetails{\addresssymbol\@addressstreet}%
         \ifthenelse{\equal{\@addresscity}{}}{}{\addtomakeheaddetails[~--~]{\@addresscity}}% if \addresstreet is defined, \addresscity and \addresscountry will always be defined but could be empty
@@ -96,7 +98,7 @@
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%
-    \flushmakeheaddetails}\fi}\\[2.5em]}% need to force a \par after this to avoid weird spacing bug at the first section if no blank line is left after \makehead
+      \flushmakeheaddetails}\fi}\\[2.5em]}% need to force a \par after this to avoid weird spacing bug at the first section if no blank line is left after \makehead
 
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
- Avoid an unnecessary empty line in body 3 when both the company name and date range are empty, enabling one to stack roles at the same company
- Avoid an unnecessary empty line in head 3 when no details (address, phone number, etc.) are provided